### PR TITLE
Add symbol and usage example for commute (removes "duplicate")

### DIFF
--- a/aplcard.tex
+++ b/aplcard.tex
@@ -579,7 +579,7 @@ Notation for commands:
 \bkey{outer product with function f}{A$\circ$.fB}
 \bkey{for each b$\in$B, apply: Ab}{A$\ddot{\;\;}$B}
 \bkey{axis: AfC, over Bth axis}{Af[B]C}
-\bkey{duplicate/commute}{}
+\bkey{commute {\tt 1-x} over array A}{$1-\ddot{\sim}A$}
 \bkey{compose}{A$\circ$B}
 
 \section{$\APLbox$CR, $\APLbox$FIO, $\APLbox$PLOT, $\APLbox$SQL}


### PR DESCRIPTION
This potentially gives an answer to #5, however it still needs a more careful look since I removed the reference to "duplicate", as I was unable to find a "duplicate" usage for `⍨` in the [APL Wiki.](https://aplwiki.com/wiki/Commute)