### PR TITLE
)OFF [exit_code] (as of v1.8 r1499)

### DIFF
--- a/aplcard.tex
+++ b/aplcard.tex
@@ -366,7 +366,7 @@ Notation for commands:
 \akey{load workspace W}{)LOAD [L] W}
 \akey{show more error info}{)MORE}
 \akey{lists symbols matching name}{)NMS [from-to]}
-\akey{quit APL}{)OFF}
+\akey{quit APL}{)OFF [exit_code]}
 \akey{show operators}{)OPS [from-to]}
 \akey{dump workspace (IBM .atf format)}{)OUT name [O $\ldots$]}
 \akey{protects during copying}{)PCOPY [L] W [O $\ldots$]}


### PR DESCRIPTION
The )OFF command as of svn r1499 takes an optional exit_code to aid in use of GNU APL in shell script modes (enabling it to return shell exit codes other than 0).